### PR TITLE
fix composer install fails with cache:clear script

### DIFF
--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -1,5 +1,5 @@
 doctrine_migrations:
-    dir_name: '%kernel.project_dir%/src/Migrations'
+    migrations_paths:
+        'DoctrineMigrations': '%kernel.project_dir%/src/Migrations'
     # namespace is arbitrary but should be different from App\Migrations
     # as migrations classes should NOT be autoloaded
-    namespace: DoctrineMigrations


### PR DESCRIPTION
Dctrine Migrations 3.1.x has a different config and the installed version is 3.1.1 with composer update runs first after changing it works as expected

Error Message:
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!
!!  In ArrayNode.php line 319:
!!
!!    Unrecognized options "dir_name, namespace" under "doctrine_migrations". Ava
!!    ilable options are "all_or_nothing", "check_database_platform", "connection
!!    ", "custom_template", "em", "enable_profiler", "factories", "migrations", "
!!    migrations_paths", "organize_migrations", "services", "storage".
!!
!!
!!
Script @auto-scripts was called via post-install-cmd

source of fix: https://github.com/doctrine/DoctrineMigrationsBundle/blob/3.1.x/UPGRADE.md